### PR TITLE
introcude SCMI agent driver

### DIFF
--- a/doc/device-tree-bindings/arm/arm,scmi.txt
+++ b/doc/device-tree-bindings/arm/arm,scmi.txt
@@ -1,0 +1,197 @@
+System Control and Management Interface (SCMI) Message Protocol
+----------------------------------------------------------
+
+The SCMI is intended to allow agents such as OSPM to manage various functions
+that are provided by the hardware platform it is running on, including power
+and performance functions.
+
+This binding is intended to define the interface the firmware implementing
+the SCMI as described in ARM document number ARM DEN 0056A ("ARM System Control
+and Management Interface Platform Design Document")[0] provide for OSPM in
+the device tree.
+
+Required properties:
+
+The scmi node with the following properties shall be under the /firmware/ node.
+
+- compatible : shall be "arm,scmi" or "arm,scmi-smc" for smc/hvc transports
+- mboxes: List of phandle and mailbox channel specifiers. It should contain
+	  exactly one or two mailboxes, one for transmitting messages("tx")
+	  and another optional for receiving the notifications("rx") if
+	  supported.
+- shmem : List of phandle pointing to the shared memory(SHM) area as per
+	  generic mailbox client binding.
+- #address-cells : should be '1' if the device has sub-nodes, maps to
+	  protocol identifier for a given sub-node.
+- #size-cells : should be '0' as 'reg' property doesn't have any size
+	  associated with it.
+- arm,smc-id : SMC id required when using smc or hvc transports
+
+Optional properties:
+
+- mbox-names: shall be "tx" or "rx" depending on mboxes entries.
+
+See Documentation/devicetree/bindings/mailbox/mailbox.txt for more details
+about the generic mailbox controller and client driver bindings.
+
+The mailbox is the only permitted method of calling the SCMI firmware.
+Mailbox doorbell is used as a mechanism to alert the presence of a
+messages and/or notification.
+
+Each protocol supported shall have a sub-node with corresponding compatible
+as described in the following sections. If the platform supports dedicated
+communication channel for a particular protocol, the 3 properties namely:
+mboxes, mbox-names and shmem shall be present in the sub-node corresponding
+to that protocol.
+
+Clock/Performance bindings for the clocks/OPPs based on SCMI Message Protocol
+------------------------------------------------------------
+
+This binding uses the common clock binding[1].
+
+Required properties:
+- #clock-cells : Should be 1. Contains the Clock ID value used by SCMI commands.
+
+Power domain bindings for the power domains based on SCMI Message Protocol
+------------------------------------------------------------
+
+This binding for the SCMI power domain providers uses the generic power
+domain binding[2].
+
+Required properties:
+ - #power-domain-cells : Should be 1. Contains the device or the power
+			 domain ID value used by SCMI commands.
+
+Sensor bindings for the sensors based on SCMI Message Protocol
+--------------------------------------------------------------
+SCMI provides an API to access the various sensors on the SoC.
+
+Required properties:
+- #thermal-sensor-cells: should be set to 1. This property follows the
+			 thermal device tree bindings[3].
+
+			 Valid cell values are raw identifiers (Sensor ID)
+			 as used by the firmware. Refer to  platform details
+			 for your implementation for the IDs to use.
+
+Reset signal bindings for the reset domains based on SCMI Message Protocol
+------------------------------------------------------------
+
+This binding for the SCMI reset domain providers uses the generic reset
+signal binding[5].
+
+Required properties:
+ - #reset-cells : Should be 1. Contains the reset domain ID value used
+		  by SCMI commands.
+
+SRAM and Shared Memory for SCMI
+-------------------------------
+
+A small area of SRAM is reserved for SCMI communication between application
+processors and SCP.
+
+The properties should follow the generic mmio-sram description found in [4]
+
+Each sub-node represents the reserved area for SCMI.
+
+Required sub-node properties:
+- reg : The base offset and size of the reserved area with the SRAM
+- compatible : should be "arm,scmi-shmem" for Non-secure SRAM based
+	       shared memory
+
+[0] http://infocenter.arm.com/help/topic/com.arm.doc.den0056a/index.html
+[1] Documentation/devicetree/bindings/clock/clock-bindings.txt
+[2] Documentation/devicetree/bindings/power/power-domain.yaml
+[3] Documentation/devicetree/bindings/thermal/thermal.txt
+[4] Documentation/devicetree/bindings/sram/sram.yaml
+[5] Documentation/devicetree/bindings/reset/reset.txt
+
+Example:
+
+sram@50000000 {
+	compatible = "mmio-sram";
+	reg = <0x0 0x50000000 0x0 0x10000>;
+
+	#address-cells = <1>;
+	#size-cells = <1>;
+	ranges = <0 0x0 0x50000000 0x10000>;
+
+	cpu_scp_lpri: scp-shmem@0 {
+		compatible = "arm,scmi-shmem";
+		reg = <0x0 0x200>;
+	};
+
+	cpu_scp_hpri: scp-shmem@200 {
+		compatible = "arm,scmi-shmem";
+		reg = <0x200 0x200>;
+	};
+};
+
+mailbox@40000000 {
+	....
+	#mbox-cells = <1>;
+	reg = <0x0 0x40000000 0x0 0x10000>;
+};
+
+firmware {
+
+	...
+
+	scmi {
+		compatible = "arm,scmi";
+		mboxes = <&mailbox 0 &mailbox 1>;
+		mbox-names = "tx", "rx";
+		shmem = <&cpu_scp_lpri &cpu_scp_hpri>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scmi_devpd: protocol@11 {
+			reg = <0x11>;
+			#power-domain-cells = <1>;
+		};
+
+		scmi_dvfs: protocol@13 {
+			reg = <0x13>;
+			#clock-cells = <1>;
+		};
+
+		scmi_clk: protocol@14 {
+			reg = <0x14>;
+			#clock-cells = <1>;
+		};
+
+		scmi_sensors0: protocol@15 {
+			reg = <0x15>;
+			#thermal-sensor-cells = <1>;
+		};
+
+		scmi_reset: protocol@16 {
+			reg = <0x16>;
+			#reset-cells = <1>;
+		};
+	};
+};
+
+cpu@0 {
+	...
+	reg = <0 0>;
+	clocks = <&scmi_dvfs 0>;
+};
+
+hdlcd@7ff60000 {
+	...
+	reg = <0 0x7ff60000 0 0x1000>;
+	clocks = <&scmi_clk 4>;
+	power-domains = <&scmi_devpd 1>;
+	resets = <&scmi_reset 10>;
+};
+
+thermal-zones {
+	soc_thermal {
+		polling-delay-passive = <100>;
+		polling-delay = <1000>;
+					/* sensor ID */
+		thermal-sensors = <&scmi_sensors0 3>;
+		...
+	};
+};

--- a/drivers/clk/Kconfig
+++ b/drivers/clk/Kconfig
@@ -152,6 +152,14 @@ config CLK_CDCE9XX
 	   Enable the clock synthesizer driver for CDCE913/925/937/949
 	   series of chips.
 
+config CLK_SCMI
+	bool "Enable SCMI clock driver"
+	select SCMI_FIRMWARE
+	help
+	  Enable this option if you want to support clock devices exposed
+	  by a SCMI agent based on SCMI clock protocol communication
+	  with a SCMI server.
+
 source "drivers/clk/analogbits/Kconfig"
 source "drivers/clk/at91/Kconfig"
 source "drivers/clk/exynos/Kconfig"

--- a/drivers/clk/Makefile
+++ b/drivers/clk/Makefile
@@ -30,6 +30,7 @@ obj-$(CONFIG_CLK_HSDK) += clk-hsdk-cgu.o
 obj-$(CONFIG_CLK_MPC83XX) += mpc83xx_clk.o
 obj-$(CONFIG_CLK_OWL) += owl/
 obj-$(CONFIG_CLK_RENESAS) += renesas/
+obj-$(CONFIG_CLK_SCMI) += clk_scmi.o
 obj-$(CONFIG_CLK_SIFIVE) += sifive/
 obj-$(CONFIG_ARCH_SUNXI) += sunxi/
 obj-$(CONFIG_CLK_STM32F) += clk_stm32f.o

--- a/drivers/clk/clk_scmi.c
+++ b/drivers/clk/clk_scmi.c
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright (C) 2019-2020 Linaro Limited
+ */
+#include <common.h>
+#include <clk-uclass.h>
+#include <dm.h>
+#include <scmi.h>
+#include <asm/types.h>
+
+enum scmi_clock_message_id {
+	SCMI_CLOCK_RATE_SET = 0x5,
+	SCMI_CLOCK_RATE_GET = 0x6,
+	SCMI_CLOCK_CONFIG_SET = 0x7,
+};
+
+#define SCMI_CLK_RATE_ASYNC_NOTIFY	BIT(0)
+#define SCMI_CLK_RATE_ASYNC_NORESP	(BIT(0) | BIT(1))
+#define SCMI_CLK_RATE_ROUND_DOWN	0
+#define SCMI_CLK_RATE_ROUND_UP		BIT(2)
+#define SCMI_CLK_RATE_ROUND_CLOSEST	BIT(3)
+
+struct scmi_clk_state_in {
+	u32 clock_id;
+	u32 attributes;
+};
+
+struct scmi_clk_state_out {
+	s32 status;
+};
+
+static int scmi_clk_gate(struct clk *clk, int enable)
+{
+	struct scmi_clk_state_in in = {
+		.clock_id = clk->id,
+		.attributes = enable,
+	};
+	struct scmi_clk_state_out out;
+	struct scmi_msg scmi_msg = {
+		.protocol_id = SCMI_PROTOCOL_ID_CLOCK,
+		.message_id = SCMI_CLOCK_CONFIG_SET,
+		.in_msg = (u8 *)&in,
+		.in_msg_sz = sizeof(in),
+		.out_msg = (u8 *)&out,
+		.out_msg_sz = sizeof(out),
+	};
+	int rc;
+
+	rc = scmi_send_and_process_msg(clk->dev->parent, &scmi_msg);
+	if (rc)
+		return rc;
+
+	return scmi_to_linux_errno(out.status);
+}
+
+static int scmi_clk_enable(struct clk *clk)
+{
+	return scmi_clk_gate(clk, 1);
+}
+
+static int scmi_clk_disable(struct clk *clk)
+{
+	return scmi_clk_gate(clk, 0);
+}
+
+struct scmi_clk_rate_get_in {
+	u32 clock_id;
+};
+
+struct scmi_clk_rate_get_out {
+	s32 status;
+	u32 rate_lsb;
+	u32 rate_msb;
+};
+
+static ulong scmi_clk_get_rate(struct clk *clk)
+{
+	struct scmi_clk_rate_get_in in = {
+		.clock_id = clk->id,
+	};
+	struct scmi_clk_rate_get_out out;
+	struct scmi_msg scmi_msg = {
+		.protocol_id = SCMI_PROTOCOL_ID_CLOCK,
+		.message_id = SCMI_CLOCK_RATE_GET,
+		.in_msg = (u8 *)&in,
+		.in_msg_sz = sizeof(in),
+		.out_msg = (u8 *)&out,
+		.out_msg_sz = sizeof(out),
+	};
+	int rc;
+
+	rc = scmi_send_and_process_msg(clk->dev->parent, &scmi_msg);
+	if (rc)
+		return 0;
+
+	rc = scmi_to_linux_errno(out.status);
+	if (rc)
+		return 0;
+
+	return (ulong)(((u64)out.rate_msb << 32) | out.rate_lsb);
+}
+
+struct scmi_clk_rate_set_in {
+	u32 clock_id;
+	u32 flags;
+	u32 rate_lsb;
+	u32 rate_msb;
+};
+
+struct scmi_clk_rate_set_out {
+	s32 status;
+};
+
+static ulong scmi_clk_set_rate(struct clk *clk, ulong rate)
+{
+	struct scmi_clk_rate_set_in in = {
+		.clock_id = clk->id,
+		.flags = SCMI_CLK_RATE_ASYNC_NORESP |
+			 SCMI_CLK_RATE_ROUND_CLOSEST,
+		.rate_lsb = (u32)rate,
+		.rate_msb = (u32)((u64)rate >> 32),
+	};
+	struct scmi_clk_rate_set_out out;
+	struct scmi_msg scmi_msg = {
+		.protocol_id = SCMI_PROTOCOL_ID_CLOCK,
+		.message_id = SCMI_CLOCK_RATE_SET,
+		.in_msg = (u8 *)&in,
+		.in_msg_sz = sizeof(in),
+		.out_msg = (u8 *)&out,
+		.out_msg_sz = sizeof(out),
+	};
+	int rc;
+
+	rc = scmi_send_and_process_msg(clk->dev->parent, &scmi_msg);
+	if (rc)
+		return 0;
+
+	return scmi_to_linux_errno(out.status);
+}
+
+static const struct clk_ops scmi_clk_ops = {
+	.enable = scmi_clk_enable,
+	.disable = scmi_clk_disable,
+	.get_rate = scmi_clk_get_rate,
+	.set_rate = scmi_clk_set_rate,
+};
+
+U_BOOT_DRIVER(scmi_clock) = {
+	.name = "scmi_clk",
+	.id = UCLASS_CLK,
+	.ops = &scmi_clk_ops,
+};

--- a/drivers/firmware/Kconfig
+++ b/drivers/firmware/Kconfig
@@ -1,6 +1,21 @@
 config FIRMWARE
 	bool "Enable Firmware driver support"
 
+config SCMI_FIRMWARE
+	bool "Enable SCMI support"
+	select FIRMWARE
+	select OF_TRANSLATE
+	depends on DM_MAILBOX || ARM_SMCCC
+	help
+	  An SCMI agent communicates with a related SCMI server firmware
+	  located in another sub-system, as a companion micro controller
+	  or a companion host in the CPU system.
+
+	  Communications between agent (client) and the SCMI server are
+	  based on message exchange. Messages can be exchange over tranport
+	  channels as a mailbox device or an Arm SMCCC service with some
+	  piece of identified shared memory.
+
 config SPL_FIRMWARE
 	bool "Enable Firmware driver support in SPL"
 	depends on FIRMWARE

--- a/drivers/firmware/Makefile
+++ b/drivers/firmware/Makefile
@@ -2,4 +2,5 @@ obj-$(CONFIG_FIRMWARE)		+= firmware-uclass.o
 obj-$(CONFIG_$(SPL_)ARM_PSCI_FW)	+= psci.o
 obj-$(CONFIG_TI_SCI_PROTOCOL)	+= ti_sci.o
 obj-$(CONFIG_SANDBOX)		+= firmware-sandbox.o
+obj-$(CONFIG_SCMI_FIRMWARE) 	+= scmi.o
 obj-$(CONFIG_ZYNQMP_FIRMWARE)	+= firmware-zynqmp.o

--- a/drivers/firmware/scmi.c
+++ b/drivers/firmware/scmi.c
@@ -1,0 +1,439 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (C) 2019-2020 Linaro Limited.
+ */
+
+#include <common.h>
+#include <cpu_func.h>
+#include <dm.h>
+#include <errno.h>
+#include <mailbox.h>
+#include <memalign.h>
+#include <scmi.h>
+#include <asm/system.h>
+#include <asm/types.h>
+#include <dm/device-internal.h>
+#include <dm/devres.h>
+#include <dm/lists.h>
+#include <dm/ofnode.h>
+#include <linux/arm-smccc.h>
+#include <linux/compat.h>
+#include <linux/errno.h>
+#include <linux/io.h>
+#include <linux/ioport.h>
+
+#define TIMEOUT_US_10MS			10000
+
+struct error_code {
+	int scmi;
+	int errno;
+};
+
+static const struct error_code scmi_linux_errmap[] = {
+	{ .scmi = SCMI_NOT_SUPPORTED, .errno = -EOPNOTSUPP, },
+	{ .scmi = SCMI_INVALID_PARAMETERS, .errno = -EINVAL, },
+	{ .scmi = SCMI_DENIED, .errno = -EACCES, },
+	{ .scmi = SCMI_NOT_FOUND, .errno = -ENOENT, },
+	{ .scmi = SCMI_OUT_OF_RANGE, .errno = -ERANGE, },
+	{ .scmi = SCMI_BUSY, .errno = -EBUSY, },
+	{ .scmi = SCMI_COMMS_ERROR, .errno = -ECOMM, },
+	{ .scmi = SCMI_GENERIC_ERROR, .errno = -EIO, },
+	{ .scmi = SCMI_HARDWARE_ERROR, .errno = -EREMOTEIO, },
+	{ .scmi = SCMI_PROTOCOL_ERROR, .errno = -EPROTO, },
+};
+
+int scmi_to_linux_errno(s32 scmi_code)
+{
+	int n;
+
+	if (scmi_code == 0)
+		return 0;
+
+	for (n = 0; n < ARRAY_SIZE(scmi_linux_errmap); n++)
+		if (scmi_code == scmi_linux_errmap[n].scmi)
+			return scmi_linux_errmap[1].errno;
+
+	return -EPROTO;
+}
+
+struct method_ops {
+	int (*process_msg)(struct udevice *dev, struct scmi_msg *msg);
+	int (*remove_agent)(struct udevice *dev);
+};
+
+struct scmi_agent {
+	struct method_ops *method_ops;
+	void *method_priv;
+};
+
+/*
+ * Shared Memory based Transport (SMT) message buffer management
+ *
+ * SMT uses 28 byte header prior message payload to handle the state of
+ * the communication channel realized by the shared memory area and
+ * to define SCMI protocol information the payload relates to.
+ */
+struct scmi_smt_header {
+	__le32 reserved;
+	__le32 channel_status;
+#define SCMI_SHMEM_CHAN_STAT_CHANNEL_ERROR	BIT(1)
+#define SCMI_SHMEM_CHAN_STAT_CHANNEL_FREE	BIT(0)
+	__le32 reserved1[2];
+	__le32 flags;
+#define SCMI_SHMEM_FLAG_INTR_ENABLED		BIT(0)
+	__le32 length;
+	__le32 msg_header;
+	u8 msg_payload[0];
+};
+
+#define SMT_HEADER_TOKEN(token)		(((token) << 18) & GENMASK(31, 18))
+#define SMT_HEADER_PROTOCOL_ID(proto)	(((proto) << 10) & GENMASK(17, 10))
+#define SMT_HEADER_MESSAGE_TYPE(type)	(((type) << 18) & GENMASK(9, 8))
+#define SMT_HEADER_MESSAGE_ID(id)	((id) & GENMASK(7, 0))
+
+struct scmi_shm_buf {
+	u8 *buf;
+	size_t size;
+};
+
+static int get_shm_buffer(struct udevice *dev, struct scmi_shm_buf *shm)
+{
+	int rc;
+	struct ofnode_phandle_args args;
+	struct resource resource;
+	fdt32_t faddr;
+	phys_addr_t paddr;
+
+	rc = dev_read_phandle_with_args(dev, "shmem", NULL, 0, 0, &args);
+	if (rc)
+		return rc;
+
+	rc = ofnode_read_resource(args.node, 0, &resource);
+	if (rc)
+		return rc;
+
+	faddr = cpu_to_fdt32(resource.start);
+	paddr = ofnode_translate_address(args.node, &faddr);
+
+	shm->size = resource_size(&resource);
+	if (shm->size < sizeof(struct scmi_smt_header)) {
+		dev_err(dev, "Shared memory buffer too small\n");
+		return -EINVAL;
+	}
+
+	shm->buf = devm_ioremap(dev, paddr, shm->size);
+	if (!shm->buf)
+		return -ENOMEM;
+
+	if (dcache_status())
+		mmu_set_region_dcache_behaviour((uintptr_t)shm->buf,
+						shm->size, DCACHE_OFF);
+
+	return 0;
+}
+
+static int write_msg_to_smt(struct udevice *dev, struct scmi_shm_buf *shm_buf,
+			    struct scmi_msg *msg)
+{
+	struct scmi_smt_header *hdr = (void *)shm_buf->buf;
+
+	if ((!msg->in_msg && msg->in_msg_sz) ||
+	    (!msg->out_msg && msg->out_msg_sz))
+		return -EINVAL;
+
+	if (!(hdr->channel_status & SCMI_SHMEM_CHAN_STAT_CHANNEL_FREE)) {
+		dev_dbg(dev, "Channel busy\n");
+		return -EBUSY;
+	}
+
+	if (shm_buf->size < (sizeof(*hdr) + msg->in_msg_sz) ||
+	    shm_buf->size < (sizeof(*hdr) + msg->out_msg_sz)) {
+		dev_dbg(dev, "Buffer too small\n");
+		return -ETOOSMALL;
+	}
+
+	/* Load message in shared memory */
+	hdr->channel_status &= ~SCMI_SHMEM_CHAN_STAT_CHANNEL_FREE;
+	hdr->length = msg->in_msg_sz + sizeof(hdr->msg_header);
+	hdr->msg_header = SMT_HEADER_TOKEN(0) |
+			  SMT_HEADER_MESSAGE_TYPE(0) |
+			  SMT_HEADER_PROTOCOL_ID(msg->protocol_id) |
+			  SMT_HEADER_MESSAGE_ID(msg->message_id);
+
+	memcpy(hdr->msg_payload, msg->in_msg, msg->in_msg_sz);
+
+	return 0;
+}
+
+static int read_resp_from_smt(struct udevice *dev, struct scmi_shm_buf *shm_buf,
+			      struct scmi_msg *msg)
+{
+	struct scmi_smt_header *hdr = (void *)shm_buf->buf;
+
+	if (!(hdr->channel_status & SCMI_SHMEM_CHAN_STAT_CHANNEL_FREE)) {
+		dev_err(dev, "Channel unexpectedly busy\n");
+		return -EBUSY;
+	}
+
+	if (hdr->channel_status & SCMI_SHMEM_CHAN_STAT_CHANNEL_ERROR) {
+		dev_err(dev, "Channel error reported, reset channel\n");
+		return -ECOMM;
+	}
+
+	if (hdr->length > msg->out_msg_sz + sizeof(hdr->msg_header)) {
+		dev_err(dev, "Buffer to small\n");
+		return -ETOOSMALL;
+	}
+
+	/* Get the data */
+	msg->out_msg_sz = hdr->length - sizeof(hdr->msg_header);
+	memcpy(msg->out_msg, hdr->msg_payload, msg->out_msg_sz);
+
+	return 0;
+}
+
+static void clear_smt_channel(struct scmi_shm_buf *shm_buf)
+{
+	struct scmi_smt_header *hdr = (void *)shm_buf->buf;
+
+	hdr->channel_status &= ~SCMI_SHMEM_CHAN_STAT_CHANNEL_ERROR;
+}
+
+struct scmi_mbox_channel {
+	struct scmi_shm_buf shm_buf;
+	struct mbox_chan mbox;
+	ulong timeout_us;
+};
+
+static int mbox_process_msg(struct udevice *dev, struct scmi_msg *msg)
+{
+	struct scmi_agent *agent = dev_get_priv(dev);
+	struct scmi_mbox_channel *chan = agent->method_priv;
+	int rc;
+
+	rc = write_msg_to_smt(dev, &chan->shm_buf, msg);
+	if (rc)
+		return rc;
+
+	/* Give shm addr to mbox in case it is meaningful */
+	rc = mbox_send(&chan->mbox, chan->shm_buf.buf);
+	if (rc) {
+		dev_err(dev, "Message send failed: %d\n", rc);
+		goto out;
+	}
+
+	/* Receive the response */
+	rc = mbox_recv(&chan->mbox, chan->shm_buf.buf, chan->timeout_us);
+	if (rc) {
+		dev_err(dev, "Response failed: %d, abort\n", rc);
+		goto out;
+	}
+
+	rc = read_resp_from_smt(dev, &chan->shm_buf, msg);
+
+out:
+	clear_smt_channel(&chan->shm_buf);
+
+	return rc;
+}
+
+struct method_ops mbox_channel_ops = {
+	.process_msg = mbox_process_msg,
+};
+
+static int probe_mailbox_channel(struct udevice *dev)
+{
+	struct scmi_agent *agent = dev_get_priv(dev);
+	struct scmi_mbox_channel *chan;
+	int rc;
+
+	chan = devm_kzalloc(dev, sizeof(*chan), GFP_KERNEL);
+	if (!chan)
+		return -ENOMEM;
+
+	chan->timeout_us = TIMEOUT_US_10MS;
+
+	rc = mbox_get_by_index(dev, 0, &chan->mbox);
+	if (rc) {
+		dev_err(dev, "Failed to find mailbox: %d\n", rc);
+		goto out;
+	}
+
+	rc = get_shm_buffer(dev, &chan->shm_buf);
+	if (rc)
+		dev_err(dev, "Failed to get shm resources: %d\n", rc);
+
+out:
+	if (rc) {
+		devm_kfree(dev, chan);
+	} else {
+		agent->method_ops = &mbox_channel_ops;
+		agent->method_priv = (void *)chan;
+	}
+
+	return rc;
+}
+
+struct scmi_arm_smc_channel {
+	ulong func_id;
+	struct scmi_shm_buf shm_buf;
+};
+
+#define SMCCC_RET_NOT_SUPPORTED         ((unsigned long)-1)
+
+static int arm_smc_process_msg(struct udevice *dev, struct scmi_msg *msg)
+{
+	struct scmi_agent *agent = dev_get_priv(dev);
+	struct scmi_arm_smc_channel *chan = agent->method_priv;
+	struct arm_smccc_res res;
+	int rc;
+
+	rc = write_msg_to_smt(dev, &chan->shm_buf, msg);
+	if (rc)
+		return rc;
+
+	arm_smccc_smc(chan->func_id, 0, 0, 0, 0, 0, 0, 0, &res);
+	if (res.a0 == SMCCC_RET_NOT_SUPPORTED)
+		rc = -EINVAL;
+	else
+		rc = read_resp_from_smt(dev, &chan->shm_buf, msg);
+
+	clear_smt_channel(&chan->shm_buf);
+
+	return rc;
+}
+
+struct method_ops arm_smc_channel_ops = {
+	.process_msg = arm_smc_process_msg,
+};
+
+static int probe_arm_smc_channel(struct udevice *dev)
+{
+	struct scmi_agent *agent = dev_get_priv(dev);
+	struct scmi_arm_smc_channel *chan;
+	ofnode node = dev_ofnode(dev);
+	u32 func_id;
+	int rc;
+
+	chan = devm_kzalloc(dev, sizeof(*chan), GFP_KERNEL);
+	if (!chan)
+		return -ENOMEM;
+
+	if (ofnode_read_u32(node, "arm,smc-id", &func_id)) {
+		dev_err(dev, "Missing property func-id\n");
+		return -EINVAL;
+	}
+
+	chan->func_id = func_id;
+
+	rc = get_shm_buffer(dev, &chan->shm_buf);
+	if (rc) {
+		dev_err(dev, "Failed to get shm resources: %d\n", rc);
+		return rc;
+	}
+
+	agent->method_ops = &arm_smc_channel_ops;
+	agent->method_priv = (void *)chan;
+
+	return rc;
+}
+
+/*
+ * Exported functions by the SCMI agent
+ */
+
+int scmi_send_and_process_msg(struct udevice *dev, struct scmi_msg *msg)
+{
+	struct scmi_agent *agent = dev_get_priv(dev);
+
+	return agent->method_ops->process_msg(dev, msg);
+}
+
+static int scmi_remove(struct udevice *dev)
+{
+	struct scmi_agent *agent = dev_get_priv(dev);
+
+	if (agent->method_ops->remove_agent)
+		return agent->method_ops->remove_agent(dev);
+
+	return 0;
+}
+
+enum scmi_transport_channel {
+	SCMI_MAILBOX_TRANSPORT,
+	SCMI_ARM_SMCCC_TRANSPORT,
+};
+
+static int scmi_probe(struct udevice *dev)
+{
+	switch (dev_get_driver_data(dev)) {
+	case SCMI_MAILBOX_TRANSPORT:
+		if (IS_ENABLED(CONFIG_DM_MAILBOX))
+			return probe_mailbox_channel(dev);
+		break;
+	case SCMI_ARM_SMCCC_TRANSPORT:
+		if (IS_ENABLED(CONFIG_ARM_SMCCC))
+			return probe_arm_smc_channel(dev);
+		break;
+	default:
+		break;
+	}
+
+	return -EINVAL;
+}
+
+static int scmi_bind(struct udevice *dev)
+{
+	int rc = 0;
+	ofnode node;
+	struct driver *drv;
+
+	dev_for_each_subnode(node, dev) {
+		u32 protocol_id;
+
+		if (!ofnode_is_available(node))
+			continue;
+
+		if (ofnode_read_u32(node, "reg", &protocol_id))
+			continue;
+
+		switch (protocol_id) {
+		default:
+			dev_info(dev, "Ignore unsupported SCMI protocol %u\n",
+				 protocol_id);
+			continue;
+		}
+
+		rc = device_bind_ofnode(dev, drv, ofnode_get_name(node),
+					NULL, node, NULL);
+		if (rc)
+			break;
+	}
+
+	if (rc)
+		device_unbind(dev);
+
+	return rc;
+}
+
+static const struct udevice_id scmi_ids[] = {
+#ifdef CONFIG_DM_MAILBOX
+	{ .compatible = "arm,scmi", .data = SCMI_MAILBOX_TRANSPORT },
+#endif
+#ifdef CONFIG_ARM_SMCCC
+	{ .compatible = "arm,scmi-smc", .data = SCMI_ARM_SMCCC_TRANSPORT },
+#endif
+	{ }
+};
+
+U_BOOT_DRIVER(scmi) = {
+	.name		= "scmi",
+	.id		= UCLASS_FIRMWARE,
+	.of_match	= scmi_ids,
+	.priv_auto_alloc_size = sizeof(struct scmi_agent),
+	.bind		= scmi_bind,
+	.probe		= scmi_probe,
+	.remove		= scmi_remove,
+	.flags		= DM_FLAG_OS_PREPARE,
+};

--- a/drivers/firmware/scmi.c
+++ b/drivers/firmware/scmi.c
@@ -399,6 +399,9 @@ static int scmi_bind(struct udevice *dev)
 			continue;
 
 		switch (protocol_id) {
+		case SCMI_PROTOCOL_ID_CLOCK:
+			drv = DM_GET_DRIVER(scmi_clock);
+			break;
 		default:
 			dev_info(dev, "Ignore unsupported SCMI protocol %u\n",
 				 protocol_id);

--- a/drivers/firmware/scmi.c
+++ b/drivers/firmware/scmi.c
@@ -402,6 +402,9 @@ static int scmi_bind(struct udevice *dev)
 		case SCMI_PROTOCOL_ID_CLOCK:
 			drv = DM_GET_DRIVER(scmi_clock);
 			break;
+		case SCMI_PROTOCOL_ID_RESET_DOMAIN:
+			drv = DM_GET_DRIVER(scmi_reset_domain);
+			break;
 		default:
 			dev_info(dev, "Ignore unsupported SCMI protocol %u\n",
 				 protocol_id);

--- a/drivers/reset/Kconfig
+++ b/drivers/reset/Kconfig
@@ -148,4 +148,11 @@ config RESET_IMX7
 	help
 	  Support for reset controller on i.MX7/8 SoCs.
 
+config RESET_SCMI
+	bool "Enable SCMI reset domain driver"
+	select SCMI_FIRMWARE
+	help
+	  Enable this option if you want to support reset controller
+	  devices exposed by a SCMI agent based on SCMI reset domain
+	  protocol communication with a SCMI server.
 endmenu

--- a/drivers/reset/Makefile
+++ b/drivers/reset/Makefile
@@ -23,3 +23,4 @@ obj-$(CONFIG_RESET_MTMIPS) += reset-mtmips.o
 obj-$(CONFIG_RESET_SUNXI) += reset-sunxi.o
 obj-$(CONFIG_RESET_HISILICON) += reset-hisilicon.o
 obj-$(CONFIG_RESET_IMX7) += reset-imx7.o
+obj-$(CONFIG_RESET_SCMI) += reset-scmi.o

--- a/drivers/reset/reset-scmi.c
+++ b/drivers/reset/reset-scmi.c
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright (C) 2019-2020 Linaro Limited
+ */
+#include <common.h>
+#include <dm.h>
+#include <errno.h>
+#include <reset-uclass.h>
+#include <scmi.h>
+#include <asm/types.h>
+
+enum scmi_reset_domain_message_id {
+	SCMI_RESET_DOMAIN_RESET = 0x4,
+};
+
+#define SCMI_RD_RESET_FLAG_ASSERT	BIT(1)
+#define SCMI_RD_RESET_FLAG_DEASSERT	0
+
+struct scmi_rd_reset_in {
+	u32 domain_id;
+	u32 flags;
+	u32 reset_state;
+};
+
+struct scmi_rd_reset_out {
+	s32 status;
+};
+
+static int scmi_reset_set_state(struct reset_ctl *rst, int assert_not_deassert)
+{
+	struct scmi_rd_reset_in in = {
+		.domain_id = rst->id,
+		.flags = assert_not_deassert ? SCMI_RD_RESET_FLAG_ASSERT :
+			 SCMI_RD_RESET_FLAG_DEASSERT,
+		.reset_state = 0,
+	};
+	struct scmi_rd_reset_out out;
+	struct scmi_msg scmi_msg = {
+		.protocol_id = SCMI_PROTOCOL_ID_RESET_DOMAIN,
+		.message_id = SCMI_RESET_DOMAIN_RESET,
+		.in_msg = (u8 *)&in,
+		.in_msg_sz = sizeof(in),
+		.out_msg = (u8 *)&out,
+		.out_msg_sz = sizeof(out),
+	};
+	int rc;
+
+	rc = scmi_send_and_process_msg(rst->dev->parent, &scmi_msg);
+	if (rc)
+		return rc;
+
+	return scmi_to_linux_errno(out.status);
+}
+
+static int scmi_reset_assert(struct reset_ctl *rst)
+{
+	return scmi_reset_set_state(rst, SCMI_RD_RESET_FLAG_ASSERT);
+}
+
+static int scmi_reset_deassert(struct reset_ctl *rst)
+{
+	return scmi_reset_set_state(rst, SCMI_RD_RESET_FLAG_DEASSERT);
+}
+
+static int scmi_reset_request(struct reset_ctl *reset_ctl)
+{
+	return 0;
+}
+
+static int scmi_reset_rfree(struct reset_ctl *reset_ctl)
+{
+	return 0;
+}
+
+static const struct reset_ops scmi_reset_domain_ops = {
+	.request	= scmi_reset_request,
+	.rfree		= scmi_reset_rfree,
+	.rst_assert	= scmi_reset_assert,
+	.rst_deassert	= scmi_reset_deassert,
+};
+
+U_BOOT_DRIVER(scmi_reset_domain) = {
+	.name = "scmi_reset_domain",
+	.id = UCLASS_RESET,
+	.ops = &scmi_reset_domain_ops,
+};

--- a/include/scmi.h
+++ b/include/scmi.h
@@ -1,0 +1,82 @@
+/* SPDX-License-Identifier: GPL-2.0+ OR BSD-3-Clause */
+/*
+ * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (C) 2019, Linaro Limited
+ */
+#ifndef SCMI_H
+#define SCMI_H
+
+#include <asm/types.h>
+
+/**
+ * An SCMI agent represent on communication path from a device driver to
+ * the remote SCMI server which driver sends messages to and receives
+ * response messages from.
+ */
+struct scmi_agent;
+
+enum scmi_std_protocol {
+	SCMI_PROTOCOL_ID_BASE = 0x10,
+	SCMI_PROTOCOL_ID_POWER_DOMAIN = 0x11,
+	SCMI_PROTOCOL_ID_SYSTEM = 0x12,
+	SCMI_PROTOCOL_ID_PERF = 0x13,
+	SCMI_PROTOCOL_ID_CLOCK = 0x14,
+	SCMI_PROTOCOL_ID_SENSOR = 0x15,
+	SCMI_PROTOCOL_ID_RESET_DOMAIN = 0x16,
+};
+
+enum scmi_status_code {
+	SCMI_SUCCESS =  0,
+	SCMI_NOT_SUPPORTED = -1,
+	SCMI_INVALID_PARAMETERS = -2,
+	SCMI_DENIED = -3,
+	SCMI_NOT_FOUND = -4,
+	SCMI_OUT_OF_RANGE = -5,
+	SCMI_BUSY = -6,
+	SCMI_COMMS_ERROR = -7,
+	SCMI_GENERIC_ERROR = -8,
+	SCMI_HARDWARE_ERROR = -9,
+	SCMI_PROTOCOL_ERROR = -10,
+};
+
+/*
+ * struct scmi_msg - Context of a SCMI message sent and the response received
+ *
+ * @protocol_id: SCMI protocol ID
+ * @message_id: SCMI message ID for a defined protocol ID
+ * @in_msg: pointer to the message payload sent by the driver
+ * @in_msg_sz: byte size of the message payload sent
+ * @out_msg: pointer to buffer to store response message payload
+ * @out_msg_size: Byte size of the response buffer or payload
+ */
+struct scmi_msg {
+	unsigned int protocol_id;
+	unsigned int message_id;
+	u8 *in_msg;
+	size_t in_msg_sz;
+	u8 *out_msg;
+	size_t out_msg_sz;
+};
+
+/**
+ * scmi_send_and_process_msg() - send and process a SCMI message
+ *
+ * Send a message to a SCMI server through a target SCMI agent device.
+ * Caller sets scmi_msg::out_msg_sz to the output message buffer size.
+ * On return, scmi_msg::out_msg_sz stores the response payload size.
+ *
+ * @dev: SCMI agent device
+ * @msg: Message structure reference
+ * @return 0 on success, a negative errno otherwise
+ */
+int scmi_send_and_process_msg(struct udevice *dev, struct scmi_msg *msg);
+
+/**
+ * scmi_to_linux_errno() - Convert an SCMI error code into a Linux errno code
+ *
+ * @scmi_errno: SCMI error code value
+ * @return 0 for successful status and a negative errno otherwise
+ */
+int scmi_to_linux_errno(s32 scmi_errno);
+
+#endif /* SCMI_H */


### PR DESCRIPTION
Introduce a SMCI agent driver and support for SCMI clock and SCMI reset domain protocol and device drivers.
With this change, SCMI agent can support 2 possible transports layers: a mailbox device based and an Arm SMC invocation based.A former change can enhance the driver to support a SMCCC conduit driver to support Arm HVC invocation path.