### PR TITLE
lib/efi_loader: fix ABI in efi_mm_communicate_header

### DIFF
--- a/include/mm_communication.h
+++ b/include/mm_communication.h
@@ -47,7 +47,7 @@ struct efi_mm_communicate_header {
 	efi_guid_t header_guid;
 	size_t     message_len;
 	u8         data[];
-};
+} __packed;
 
 #define MM_COMMUNICATE_HEADER_SIZE \
 	(sizeof(struct efi_mm_communicate_header))


### PR DESCRIPTION
Pack `struct efi_mm_communicate_header` as done in EDK2. If not the structure takes 4 additional bytes on 32bit targets which breaks ABI. 